### PR TITLE
Fix MongoDB authentication configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,45 @@ mongodb:
     enabled: "is_active"       # 自定义启用状态字段
 ```
 
+### Docker Compose MongoDB 认证配置
+
+如果您使用 Docker Compose 启动 MongoDB（如本项目的 docker-compose.yml），MongoDB 会启用认证。您需要在配置文件中提供正确的认证信息：
+
+```yaml
+mongodb:
+  # 包含认证信息的 MongoDB URI
+  uri: "mongodb://admin:password@localhost:27017/stun_turn?authSource=admin"
+  database: "stun_turn"
+  collection: "users"
+```
+
+**重要说明**：
+- `admin:password` 是 Docker Compose 中配置的用户名和密码
+- `authSource=admin` 指定认证数据库为 admin
+- 如果不提供认证信息，会出现 `(Unauthorized) command createIndexes requires authentication` 错误
+
+参考 `configs/config.dev.yaml` 文件查看完整的开发环境配置示例。
+
+## 故障排除
+
+### MongoDB 认证错误
+
+**错误信息**：
+```
+failed to create indexes: failed to create username index: (Unauthorized) command createIndexes requires authentication
+```
+
+**解决方案**：
+1. 确保 MongoDB URI 包含正确的认证信息
+2. 检查用户名、密码和认证数据库是否正确
+3. 确认 MongoDB 容器已完全启动（等待 10-15 秒）
+
+**正确的配置示例**：
+```yaml
+mongodb:
+  uri: "mongodb://admin:password@localhost:27017/stun_turn?authSource=admin"
+```
+
 ## API 端点
 
 ### 健康检查端点

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -1,0 +1,55 @@
+# Pion STUN/TURN Server Development Configuration
+# This file demonstrates the correct MongoDB URI format for local development
+# with Docker Compose authentication
+
+server:
+  stun:
+    port: 3478
+    address: "0.0.0.0"
+  
+  turn:
+    port: 3479
+    address: "0.0.0.0"
+    realm: "pion-stun-turn"
+    public_ip: ""  # Set to your public IP for production
+    relay_ranges:
+      - "10.0.0.0/8"
+      - "172.16.0.0/12"
+      - "192.168.0.0/16"
+    max_lifetime: 3600  # seconds
+    default_ttl: 600    # seconds
+  
+  health:
+    port: 8080
+    address: "0.0.0.0"
+    path: "/health"
+
+mongodb:
+  # MongoDB URI with authentication for Docker Compose setup
+  # Format: mongodb://username:password@host:port/database?authSource=admin
+  uri: "mongodb://admin:password@localhost:27017/stun_turn?authSource=admin"
+  database: "stun_turn"
+  collection: "users"
+  
+  # Customizable field names for authentication
+  fields:
+    username: "username"
+    password: "password"
+    enabled: "enabled"
+    salt: "salt"
+  
+  # Connection options
+  options:
+    max_pool_size: 10
+    min_pool_size: 1
+    connect_timeout: 10      # seconds
+    server_selection_timeout: 5  # seconds
+
+logging:
+  level: "info"     # trace, debug, info, warn, error, fatal, panic
+  format: "json"    # json, text
+  output: "stdout"  # stdout, stderr, file path
+
+security:
+  password_hash_cost: 12
+  secret_key: "your-secret-key-here"


### PR DESCRIPTION
- Add config.dev.yaml with correct MongoDB URI format for Docker Compose
- Update README.md with troubleshooting section for MongoDB auth errors
- Document proper MongoDB URI format with authentication credentials
- Provide solution for 'createIndexes requires authentication' error

The MongoDB URI now includes:
- Username and password (admin:password)
- Authentication source (authSource=admin)
- Correct database name (stun_turn)

This resolves the authentication error when connecting to MongoDB started with Docker Compose.